### PR TITLE
Fix an issue with loading structured DataTypes that are subtypes of abstract structures.

### DIFF
--- a/backends/open62541/src/DataTypeImporter.c
+++ b/backends/open62541/src/DataTypeImporter.c
@@ -352,7 +352,9 @@ static void setDataTypeMembersTypeIndex(DataTypeImporter *importer,
 #endif
         // copy over parent members, if no members (abstract type), nothing is
         // done
-        if (parentType->members)
+        // First need to check if parentType exists at all. NodesetCompiler in
+        // open62541 would not generate a type if it had no members.
+        if (parentType && parentType->members)
         {
             UA_DataTypeMember *members = (UA_DataTypeMember *)calloc(
                 (size_t)(parentType->membersSize + type->membersSize),


### PR DESCRIPTION
NodesetCompiler in open62541 doesn't generate a DataType description struct unless the type has any members.