### PR TITLE
fix(backends): fixed struct size calculation when setting its value

### DIFF
--- a/backends/open62541/src/Value.c
+++ b/backends/open62541/src/Value.c
@@ -311,7 +311,9 @@ static void setStructure(const NL_Data *value, const UA_DataType *type,
         }
         else
         {
+            size_t structOffset = data->offset + memberType->memSize;
             setScalar(memberData, memberType, data, customTypes, serverContext);
+            data->offset = structOffset;
         }
     }
 }
@@ -429,6 +431,7 @@ static void setArray(const NL_Data *value, const UA_DataType *type, RawData *dat
 {
     for (size_t i = 0; i < value->val.complexData.membersSize; i++)
     {
+        data->offset = i * type->memSize;
         setScalar(value->val.complexData.members[i], type, data, customTypes, serverContext);
     }
 }


### PR DESCRIPTION
In some cases the structure size was not calculated correctly when reading setting its value. This becomes apparent when we're dealing with nested structures (or nested arrays of structures).
The size of a structure is not equal to the sum of its members. It's not enough to increment the offset after adding each member, the size of the whole structure needs to be considered